### PR TITLE
colors/molokai.vim: reverting FG for DiffDelete as it looks bad in fugitive patches

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -29,7 +29,7 @@ hi Delimiter       guifg=#8F8F8F
 
 hi DiffAdd                       guibg=#005f00
 hi DiffChange                    guibg=#4B1818
-hi DiffDelete      guifg=#000000 guibg=#5f0000
+hi DiffDelete      guifg=#960050 guibg=#5f0000
 hi DiffText                      guibg=#870000 gui=bold
 
 hi Directory       guifg=#A6E22E               gui=bold


### PR DESCRIPTION
Originally modified in commit ebe2c0ea7a40a9667cfaaf66520230426ba2157c
Patches like this look bad (black foreground for lines starting with '-'):

diff --git a/colors/molokai.vim b/colors/molokai.vim
index c7a9d9b..95f0b06 100644
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -29,7 +29,7 @@ hi Delimiter       guifg=#8F8F8F

 hi DiffAdd                       guibg=#005f00
 hi DiffChange                    guibg=#4B1818
-hi DiffDelete      guifg=#000000 guibg=#5f0000
+hi DiffDelete      guifg=#960050 guibg=#5f0000
 hi DiffText                      guibg=#870000 gui=bold

 hi Directory       guifg=#A6E22E               gui=bold